### PR TITLE
proof of concept: compression support

### DIFF
--- a/Network/Kafka/Producer.hs
+++ b/Network/Kafka/Producer.hs
@@ -99,7 +99,7 @@ defaultMessageKey = Key Nothing
 
 -- | Default: @0@
 defaultMessageAttributes :: Attributes
-defaultMessageAttributes = 0
+defaultMessageAttributes = Attributes NoCompression
 
 -- | Construct a message from a string of bytes using default attributes.
 makeMessage :: ByteString -> Message

--- a/Network/Kafka/Producer.hs
+++ b/Network/Kafka/Producer.hs
@@ -34,11 +34,11 @@ produceRequest ra ti ts =
 
 -- | Send messages to partition calculated by 'partitionAndCollate'.
 produceMessages :: Kafka m => [TopicAndMessage] -> m [ProduceResponse]
-produceMessages = prod (groupMessages NoCompression)
+produceMessages = prod (groupMessagesToSet NoCompression)
 
 -- | Send compressed messages to partition calculated by 'partitionAndCollate'.
 produceCompressedMessages :: Kafka m => CompressionCodec -> [TopicAndMessage] -> m [ProduceResponse]
-produceCompressedMessages c = prod (groupMessages c)
+produceCompressedMessages c = prod (groupMessagesToSet c)
 
 prod :: Kafka m => ([TopicAndMessage] -> MessageSet) -> [TopicAndMessage] -> m [ProduceResponse]
 prod g tams = do
@@ -46,12 +46,8 @@ prod g tams = do
   mapM (uncurry send) $ fmap M.toList <$> M.toList m
 
 -- | Create a protocol message set from a list of messages.
-{-# DEPRECATED groupMessagesToSet "Use groupMessages instead" #-}
-groupMessagesToSet :: [TopicAndMessage] -> MessageSet
-groupMessagesToSet = groupMessages NoCompression
-
-groupMessages :: CompressionCodec -> [TopicAndMessage] -> MessageSet
-groupMessages c xs = MessageSet c $ msm <$> xs
+groupMessagesToSet :: CompressionCodec -> [TopicAndMessage] -> MessageSet
+groupMessagesToSet c xs = MessageSet c $ msm <$> xs
     where msm = MessageSetMember (Offset (-1)) . _tamMessage
 
 -- | Group messages together with the leader they should be sent to.

--- a/Network/Kafka/Producer.hs
+++ b/Network/Kafka/Producer.hs
@@ -51,11 +51,8 @@ groupMessagesToSet :: [TopicAndMessage] -> MessageSet
 groupMessagesToSet = groupMessages NoCompression
 
 groupMessages :: CompressionCodec -> [TopicAndMessage] -> MessageSet
-groupMessages c xs = msgSet c $ msm <$> xs
-    where msgSet NoCompression = MessageSet
-          msgSet cc = CompressedMessageSet cc
-
-          msm = MessageSetMember (Offset (-1)) . _tamMessage
+groupMessages c xs = MessageSet c $ msm <$> xs
+    where msm = MessageSetMember (Offset (-1)) . _tamMessage
 
 -- | Group messages together with the leader they should be sent to.
 partitionAndCollate :: Kafka m => [TopicAndMessage] -> m (M.Map Leader (M.Map TopicAndPartition [TopicAndMessage]))

--- a/milena.cabal
+++ b/milena.cabal
@@ -52,7 +52,8 @@ library
                        resource-pool >=0.2.3.2  && <0.3,
                        lifted-base   >=0.2.3.6  && <0.3,
                        murmur-hash   >=0.1.0.8  && <0.2,
-                       semigroups    >=0.16.2.2 && <0.19
+                       semigroups    >=0.16.2.2 && <0.19,
+                       zlib          >=0.6.1.2  && <0.7
 
 test-suite test
   default-language: Haskell2010

--- a/test/tests.hs
+++ b/test/tests.hs
@@ -63,7 +63,7 @@ specs = do
 
         case getPartitionByKey (B.pack key) info of
           Just PartitionAndLeader { _palLeader = leader, _palPartition = partition } -> do
-            let payload = [(TopicAndPartition topic partition, groupMessages NoCompression messages)]
+            let payload = [(TopicAndPartition topic partition, groupMessagesToSet NoCompression messages)]
                 s = stateBrokers . at leader
             [(_topicName, [(_, NoError, offset)])] <- _produceResponseFields <$> send leader payload
             broker <- findMetadataOrElse [topic] s (KafkaInvalidBroker leader)


### PR DESCRIPTION
Hi,

This PR adds the ability to read and send gzipped messages. Information about representation of compressed messages was taken from https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Compression and https://cwiki.apache.org/confluence/display/KAFKA/Compression.

This is my first real-world Haskell library contribution (it was made as a part of my thesis), I would appreciate any feedback and I will do my best to adapt to changes necessary for merging this.

Parts I am not particularly sure about:
* how to represent compression codec constants (0 for none, 1 for gzip, etc.)
* how to properly parse compression information from Attributes - current solution will stop working, if attributes contain any other information
* naming, especially in Producer module

Please let me know what you think about this. Thank you!

Pavel